### PR TITLE
Linter: scan for whitespace mistakes and deduct less marks to those mistakes

### DIFF
--- a/backend/linter/src/main/scala/linter/LinterError.scala
+++ b/backend/linter/src/main/scala/linter/LinterError.scala
@@ -8,11 +8,13 @@ package linter
   * @param lineNo Line index of the mistake
   * @param colNo  the column number of the mistake
   */
-class LinterError(msg: String, file: String, lineNo: Int, colNo: Int) {
-  val _msg = msg
-  val _lineNo = lineNo
-  val _colNo = colNo
-
+class LinterError(msg: String, file: String, lineNo: Int, colNo: Int, value: Double, t: String) {
+  implicit val _msg = msg
+  implicit val _lineNo = lineNo
+  implicit val _colNo = colNo
+  implicit val _file = file
+  implicit val _type = t
+  OutputGenerator.addScore(value)
   override def toString: String = s"$file:$lineNo:$colNo: $msg"
 
 }

--- a/backend/linter/src/main/scala/linter/linters/LengthCheckerLinter.scala
+++ b/backend/linter/src/main/scala/linter/linters/LengthCheckerLinter.scala
@@ -27,7 +27,7 @@ class LengthCheckerLinter(path: File, language: Language.Value) extends BaseLint
   private def scanFile(f: File): Unit = {
     for ((line, index) <- Source.fromFile(f).getLines().zipWithIndex) {
       if (line.length >= 80) {
-        mistakes += new LinterError("Line is over 80 characters", f.toString, index + 1, 0)
+        mistakes += new LinterError("Line is over 80 characters", f.toString, index + 1, 0, 0, "style")
       }
     }
   }


### PR DESCRIPTION
If requested, the weight can be turned into a variable controlled by JSON
## This requires both hlint and scan to be installed on the test machine
this can be achieved with `cabal update && cabal install hlint scan`