### PR TITLE
POM: Disable surefire for linter & json_parser

### DIFF
--- a/backend/linter/pom.xml
+++ b/backend/linter/pom.xml
@@ -100,7 +100,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.7</version>
                 <configuration>
-                    <skipTests>true</skipTests>
+                   <printSummary>false</printSummary>
                 </configuration>
             </plugin>
             <plugin>

--- a/lib/json_parser/pom.xml
+++ b/lib/json_parser/pom.xml
@@ -59,21 +59,32 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
+              </plugin>
+              <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
                 <configuration>
-                    <useFile>false</useFile>
-                    <disableXmlReport>true</disableXmlReport>
-                    <!-- If you have classpath issue like NoDefClassError,... -->
-                    <!-- useManifestOnlyJar>false</useManifestOnlyJar -->
-                    <includes>
-                        <include>**/*Test.*</include>
-                        <include>**/*Suite.*</include>
-                    </includes>
+                   <printSummary>false</printSummary>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <junitxml>.</junitxml>
+                    <filereports>WDF TestSuite.txt</filereports>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Linter and JSONParser do not use surefire, but they still print a "0 tests run" which is false.
This disables the output from surefire so that only scalatest is shown