### PR TITLE
Add a Haskell Complexity Analyser

### DIFF
--- a/backend/complexity_analyser/.gitignore
+++ b/backend/complexity_analyser/.gitignore
@@ -1,0 +1,41 @@
+# use glob syntax.
+syntax: glob
+*.ser
+*.class
+*~
+*.bak
+#*.off
+*.old
+
+# eclipse conf file
+.settings
+.classpath
+.project
+.manager
+.scala_dependencies
+
+# idea
+.idea
+*.iml
+
+# building
+target
+build
+null
+tmp*
+temp*
+dist
+test-output
+build.log
+
+# other scm
+.svn
+.CVS
+.hg*
+
+# switch to regexp syntax.
+#  syntax: regexp
+#  ^\.pc/
+
+#SHITTY output not in target directory
+build.log

--- a/backend/complexity_analyser/pom.xml
+++ b/backend/complexity_analyser/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>backend</artifactId>
+        <groupId>automarker</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>complexity_analyser</groupId>
+    <artifactId>complexity_analyser</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <scala.version>2.11.8</scala.version>
+        <scala.version.tools>2.11</scala.version.tools>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>res/</directory>
+                <includes>
+                    <include>Bench.hs</include>
+                </includes>
+            </resource>
+        </resources>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <!-- this is so we don't end with a compile error in maven-compiler-plugin -->
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>json_parser</groupId>
+            <artifactId>json_parser</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scalacheck</groupId>
+            <artifactId>scalacheck_${scala.version.tools}</artifactId>
+            <version>1.13.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.version.tools}</artifactId>
+            <version>3.0.0-SNAP1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/backend/complexity_analyser/res/Bench.hs
+++ b/backend/complexity_analyser/res/Bench.hs
@@ -1,9 +1,33 @@
 module Bench where
-import IC.TestSuite
+import IC.TestSuite hiding (goTest, goTestOne)
+
+import Control.Exception
+import Control.Monad
+import Data.List
 
 import Tests hiding (main)
 
 import Criterion.Main
 
-runTests' = map $ \t@(TestCase s func arg) -> bench s $ whnf goTest t
+
+goTest (TestCase name f cases) = do
+  counts <- forM cases (handle majorExceptionHandler . goTestOne name f)
+  return True
+  where
+    majorExceptionHandler :: SomeException -> IO Bool
+    majorExceptionHandler e = return False
+
+goTestOne name f (input, expected) = handle exceptionHandler $ do
+      r <- evaluate (f input)
+      return True
+      where
+        failedStanza :: Show x => Bool -> x -> IO Bool
+        failedStanza _ _ = do
+          return False
+
+        exceptionHandler :: SomeException -> IO Bool
+        exceptionHandler = failedStanza True
+
+
+runTests' = map $ \t@(TestCase s func arg) -> bench s $ whnfIO (goTest t)
 main = defaultMain [bgroup "tests" (runTests' allTestCases)]

--- a/backend/complexity_analyser/res/Bench.hs
+++ b/backend/complexity_analyser/res/Bench.hs
@@ -1,0 +1,9 @@
+module Bench where
+import IC.TestSuite
+
+import Tests hiding (main)
+
+import Criterion.Main
+
+runTests' = map $ \t@(TestCase s func arg) -> bench s $ whnf goTest t
+main = defaultMain [bgroup "tests" (runTests' allTestCases)]

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -23,7 +23,7 @@ object App {
       case "haskell" =>
         val h = new HaskellProcessor(modelAnswer, inputPath)
         h.prepare()
-        println(h.runTests())
+        h.runTests()
         h.runBench()
       case _ => throw new IllegalArgumentException("Wrong language")
     }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -14,15 +14,18 @@ import scala.collection.mutable.ArrayBuffer
 object App {
   private val errorList = new ArrayBuffer[String]
 
-  def main(args: Array[String]):Unit = {
+  def main(args: Array[String]): Unit = {
+    if (args.length != 2)
+      throw new IllegalArgumentException("CompAnal <input.json> <output.json>")
     val mi = MicroServiceInputParser.parseFile(new File(args apply 0))
     val language = mi.getLanguage
     val modelAnswer = new File(mi.getModelAnswer)
     val inputPath = new File(mi.getPath)
-    val (annotations, score) = processLanguage(language, modelAnswer, inputPath)
+    val (annotations, score) : (Seq[Error], Double) = processLanguage(language, modelAnswer, inputPath)
 
     MicroServiceOutputParser.writeFile(new File(args apply 1), score,
       annotations.asJava, errorList.asJava)
+    System.exit(0)
   }
 
   def processLanguage(language: String, modelAnswer: File, inputPath: File) = {
@@ -32,7 +35,11 @@ object App {
         h.prepare()
         val (errors, score) = h.runTests()
         val (compErrors, compScore) = h.runBench()
-        (errors ++ compErrors, (score - compScore) % 100)
+        val finalScore = if (score - compScore <= 0)
+          0
+        else
+          score - compScore
+        (errors ++ compErrors, finalScore)
       case _ => throw new IllegalArgumentException("Wrong language")
     }
   }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -2,20 +2,30 @@ package complexity_analyser
 
 import java.io.File
 
-import json_parser.MicroServiceInputParser
+import scala.collection.JavaConverters._
+import json_parser.{MicroServiceOutputParser, Error, MicroServiceInputParser}
+
+import scala.collection.mutable.ArrayBuffer
 
 
 /**
   * Simple main to check the access to resources
   */
 object App {
-  def main(args: Array[String]) = {
+
+  val annotations = new ArrayBuffer[Error]
+  val errorList = new ArrayBuffer[String]
+  var score = 100
+
+  def main(args: Array[String]):Unit = {
     val mi = MicroServiceInputParser.parseFile(new File(args apply 0))
     val language = mi.getLanguage
     val modelAnswer = new File(mi.getModelAnswer)
     val inputPath = new File(mi.getPath)
     processLanguage(language, modelAnswer, inputPath)
 
+    MicroServiceOutputParser.writeFile(new File(args apply 1), score,
+      annotations.asJava, errorList.asJava)
   }
 
   def processLanguage(language: String, modelAnswer: File, inputPath: File): Unit = {
@@ -24,7 +34,9 @@ object App {
         val h = new HaskellProcessor(modelAnswer, inputPath)
         h.prepare()
         h.runTests()
-        h.runBench()
+        val hBench = h.runBench()
+        annotations ++= hBench._1
+        score = hBench._2
       case _ => throw new IllegalArgumentException("Wrong language")
     }
   }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -2,51 +2,28 @@ package complexity_analyser
 
 import java.io.File
 
-import scala.sys.process.{ProcessLogger, _}
-import json_parser.{Error, MicroServiceInputParser, MicroServiceOutputParser}
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
+import json_parser.MicroServiceInputParser
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
 
+/**
+  * Simple main to check the access to resources
+  */
 object App {
+  def main(args: Array[String]) = {
+    val mi = MicroServiceInputParser.parseFile(new File(args apply 0))
+    val language = mi.getLanguage
+    val modelAnswer = new File(mi.getModelAnswer)
+    val inputPath = new File(mi.getPath)
+    processLanguage(language, modelAnswer, inputPath)
 
-  private var path: File = _
-  private var score: Int = 100
-  val annotations = new ArrayBuffer[Error]
-  val errorList = new ArrayBuffer[String]
-
-  def main(args: Array[String]) {
-    if (args.length != 2) {
-      throw new IllegalArgumentException("Complexity <input json> ")
-    }
-    val parser = MicroServiceInputParser.parseFile(new File(args.apply(0)))
-
-    path = new File(parser.getPath)
-    val language = parser.getLanguage
-    if (complexity(language, path) != 0) {
-      score = 0
-    }
-
-    MicroServiceOutputParser.writeFile(new File(args.apply(1)), score,
-      annotations.asJava, errorList.asJava)
   }
-
-  private def complexity(language: String, path: File): Int = language match {
-    case "haskell" =>
-      runBench(path)
-      1
-
-    case "java" =>
-      0
-
-    case _ => throw new NotImplementedException
-  }
-
-  def runBench(path: File) = {
-    val lines = new ArrayBuffer[String]()
-    val exit = s"ghc -i$path/IC -i$path --make -O Bench -main-is Bench" !
-      ProcessLogger(line => lines.append(line))
-    print(exit)
+  def processLanguage(language: String, modelAnswer: File, inputPath: File): Unit = {
+    language match {
+      case "haskell" =>
+        val h = new HaskellProcessor(modelAnswer, inputPath)
+        h.prepare()
+      case _ => throw new IllegalArgumentException("Wrong language")
+    }
   }
 }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -30,8 +30,9 @@ object App {
       case "haskell" =>
         val h = new HaskellProcessor(modelAnswer, inputPath)
         h.prepare()
-        h.runTests()
-        h.runBench()
+        val (errors, score) = h.runTests()
+        val (compErrors, compScore) = h.runBench()
+        (errors ++ compErrors, (score - compScore) % 100)
       case _ => throw new IllegalArgumentException("Wrong language")
     }
   }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import json_parser.MicroServiceInputParser
 
-import scala.io.Source
 
 /**
   * Simple main to check the access to resources
@@ -18,11 +17,14 @@ object App {
     processLanguage(language, modelAnswer, inputPath)
 
   }
+
   def processLanguage(language: String, modelAnswer: File, inputPath: File): Unit = {
     language match {
       case "haskell" =>
         val h = new HaskellProcessor(modelAnswer, inputPath)
         h.prepare()
+        println(h.runTests())
+        h.runBench()
       case _ => throw new IllegalArgumentException("Wrong language")
     }
   }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -12,31 +12,26 @@ import scala.collection.mutable.ArrayBuffer
   * Simple main to check the access to resources
   */
 object App {
-
-  val annotations = new ArrayBuffer[Error]
-  val errorList = new ArrayBuffer[String]
-  var score = 100
+  private val errorList = new ArrayBuffer[String]
 
   def main(args: Array[String]):Unit = {
     val mi = MicroServiceInputParser.parseFile(new File(args apply 0))
     val language = mi.getLanguage
     val modelAnswer = new File(mi.getModelAnswer)
     val inputPath = new File(mi.getPath)
-    processLanguage(language, modelAnswer, inputPath)
+    val (annotations, score) = processLanguage(language, modelAnswer, inputPath)
 
     MicroServiceOutputParser.writeFile(new File(args apply 1), score,
       annotations.asJava, errorList.asJava)
   }
 
-  def processLanguage(language: String, modelAnswer: File, inputPath: File): Unit = {
+  def processLanguage(language: String, modelAnswer: File, inputPath: File) = {
     language match {
       case "haskell" =>
         val h = new HaskellProcessor(modelAnswer, inputPath)
         h.prepare()
         h.runTests()
-        val hBench = h.runBench()
-        annotations ++= hBench._1
-        score = hBench._2
+        h.runBench()
       case _ => throw new IllegalArgumentException("Wrong language")
     }
   }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -2,16 +2,51 @@ package complexity_analyser
 
 import java.io.File
 
-import scala.io.Source
+import scala.sys.process.{ProcessLogger, _}
+import json_parser.{Error, MicroServiceInputParser, MicroServiceOutputParser}
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
-/**
-  * Simple main to check the access to resources
-  */
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
 object App {
-  def main(args: Array[String]) = {
-    val bench = new File(getClass.getResource("/Bench.hs").toURI)
-    for(line <- Source.fromFile(bench).getLines()) {
-      println(line)
+
+  private var path: File = _
+  private var score: Int = 100
+  val annotations = new ArrayBuffer[Error]
+  val errorList = new ArrayBuffer[String]
+
+  def main(args: Array[String]) {
+    if (args.length != 2) {
+      throw new IllegalArgumentException("Complexity <input json> ")
     }
+    val parser = MicroServiceInputParser.parseFile(new File(args.apply(0)))
+
+    path = new File(parser.getPath)
+    val language = parser.getLanguage
+    if (complexity(language, path) != 0) {
+      score = 0
+    }
+
+    MicroServiceOutputParser.writeFile(new File(args.apply(1)), score,
+      annotations.asJava, errorList.asJava)
+  }
+
+  private def complexity(language: String, path: File): Int = language match {
+    case "haskell" =>
+      runBench(path)
+      1
+
+    case "java" =>
+      0
+
+    case _ => throw new NotImplementedException
+  }
+
+  def runBench(path: File) = {
+    val lines = new ArrayBuffer[String]()
+    val exit = s"ghc -i$path/IC -i$path --make -O Bench -main-is Bench" !
+      ProcessLogger(line => lines.append(line))
+    print(exit)
   }
 }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/App.scala
@@ -1,0 +1,17 @@
+package complexity_analyser
+
+import java.io.File
+
+import scala.io.Source
+
+/**
+  * Simple main to check the access to resources
+  */
+object App {
+  def main(args: Array[String]) = {
+    val bench = new File(getClass.getResource("/Bench.hs").toURI)
+    for(line <- Source.fromFile(bench).getLines()) {
+      println(line)
+    }
+  }
+}

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
@@ -2,7 +2,13 @@ package complexity_analyser
 
 import java.io.File
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+<<<<<<< HEAD
 import java.nio.file.Files.copy
+=======
+
+import scala.collection.mutable.ArrayBuffer
+import scala.sys.process._
+>>>>>>> a682795... Backend: CompAnal: run tests and bench on submissions
 
 class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
   private final val BENCH_NAME = "/Bench.hs"
@@ -15,9 +21,38 @@ class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
     if (!bench.exists()) throw new Exception("Missing resource Bench.hs")
     if (!modelAnswer.isDirectory) throw new Exception("Model solution should be a directory")
     if (!studentSubmission.isDirectory) throw new Exception("Student submission should be a directory")
-    val mod =new File(modelAnswer.toPath.toString + BENCH_NAME).toPath
+    val mod = new File(modelAnswer.toPath.toString + BENCH_NAME).toPath
     val stud = new File(studentSubmission.toPath.toString + BENCH_NAME).toPath
     copy(bench.toPath, mod, REPLACE_EXISTING)
     copy(bench.toPath, stud, REPLACE_EXISTING)
   }
+
+
+  def runTests() = {
+    val (linesModel, linesStudent) = executeOnBoth("Tests")
+    val testOutcomeStudent = s"$studentSubmission/Tests".!!
+    val testOutcomeModel = s"$modelAnswer/Tests".!!
+    testOutcomeModel.equals(testOutcomeStudent)
+  }
+
+  private def executeOnBoth(name: String) = {
+    val linesModel = new ArrayBuffer[String]()
+    val linesStudent = new ArrayBuffer[String]
+    val exitModel = s"ghc -i$modelAnswer/IC -i$modelAnswer --make -O $name -main-is $name" !
+      ProcessLogger(line => linesModel.append(line))
+    val exitStundent = s"ghc -i$studentSubmission/IC -i$studentSubmission --make -O $name -main-is $name" !
+      ProcessLogger(line => linesStudent.append(line))
+    if (exitModel != 0 || exitStundent != 0) throw new Exception(s"Student or Model $name solution didn't compile")
+    (linesModel, linesStudent)
+  }
+
+  def runBench() = {
+    val (linesModel, linesStudent) = executeOnBoth("Bench")
+    println("Student")
+    val benchOutcomeStudent = s"$studentSubmission/Bench --output=res.html".!!
+    println("Model")
+    val benchOutcomeModel = s"$modelAnswer/Bench --output=res.html".!!
+    println(benchOutcomeModel, benchOutcomeStudent)
+  }
+
 }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
@@ -1,0 +1,23 @@
+package complexity_analyser
+
+import java.io.File
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.Files.copy
+
+class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
+  private final val BENCH_NAME = "/Bench.hs"
+
+  /**
+    * Copies Bench.hs to both model solution and student submission
+    */
+  def prepare(): Unit = {
+    val bench = new File(getClass.getResource(BENCH_NAME).toURI)
+    if (!bench.exists()) throw new Exception("Missing resource Bench.hs")
+    if (!modelAnswer.isDirectory) throw new Exception("Model solution should be a directory")
+    if (!studentSubmission.isDirectory) throw new Exception("Student submission should be a directory")
+    val mod =new File(modelAnswer.toPath.toString + BENCH_NAME).toPath
+    val stud = new File(studentSubmission.toPath.toString + BENCH_NAME).toPath
+    copy(bench.toPath, mod, REPLACE_EXISTING)
+    copy(bench.toPath, stud, REPLACE_EXISTING)
+  }
+}

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
@@ -1,17 +1,16 @@
 package complexity_analyser
 
 import java.io.File
-import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-<<<<<<< HEAD
 import java.nio.file.Files.copy
-=======
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
 import scala.collection.mutable.ArrayBuffer
 import scala.sys.process._
->>>>>>> a682795... Backend: CompAnal: run tests and bench on submissions
 
 class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
   private final val BENCH_NAME = "/Bench.hs"
+  private final val MATCH_BMARK = "benchmarking tests/[a-zA-Z0-9]+".r
+  private final val MATCH_MEAN = "[0-9]+\\.[0-9]+".r
 
   /**
     * Copies Bench.hs to both model solution and student submission
@@ -40,19 +39,28 @@ class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
     val linesStudent = new ArrayBuffer[String]
     val exitModel = s"ghc -i$modelAnswer/IC -i$modelAnswer --make -O $name -main-is $name" !
       ProcessLogger(line => linesModel.append(line))
-    val exitStundent = s"ghc -i$studentSubmission/IC -i$studentSubmission --make -O $name -main-is $name" !
+    val exitStudent = s"ghc -i$studentSubmission/IC -i$studentSubmission " +
+      s"--make -O $name -main-is $name" !
       ProcessLogger(line => linesStudent.append(line))
-    if (exitModel != 0 || exitStundent != 0) throw new Exception(s"Student or Model $name solution didn't compile")
+    if (exitModel != 0 || exitStudent != 0) throw new Exception(s"Student or Model " +
+      s"$name solution didn't compile")
     (linesModel, linesStudent)
+  }
+
+  private def genListBenchNameMean(outcome: String) = {
+    val names = MATCH_BMARK.findAllMatchIn(outcome).map(_.toString())
+    val details = MATCH_BMARK.split(outcome)
+    val means = details.flatMap(_.split("\n")).filter(_.startsWith("mean"))
+    val doubles = means.map(e => MATCH_MEAN.findFirstIn(e).get.toDouble)
+    names.toSeq.zip(doubles)
   }
 
   def runBench() = {
     val (linesModel, linesStudent) = executeOnBoth("Bench")
-    println("Student")
     val benchOutcomeStudent = s"$studentSubmission/Bench --output=res.html".!!
-    println("Model")
     val benchOutcomeModel = s"$modelAnswer/Bench --output=res.html".!!
-    println(benchOutcomeModel, benchOutcomeStudent)
+    val zippedMeanModel = genListBenchNameMean(benchOutcomeModel)
+    val zippedMeanStud = genListBenchNameMean(benchOutcomeStudent)
   }
 
 }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
@@ -57,8 +57,10 @@ class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
 
   def runBench() = {
     val (linesModel, linesStudent) = executeOnBoth("Bench")
-    val benchOutcomeStudent = s"$studentSubmission/Bench --output=res.html".!!
-    val benchOutcomeModel = s"$modelAnswer/Bench --output=res.html".!!
+    val benchOutcomeStudent = s"$studentSubmission/Bench " +
+      s"--output=$studentSubmission/res.html".!!
+    val benchOutcomeModel = s"$modelAnswer/Bench " +
+      s"--output=$modelAnswer/res.html".!!
     val zippedMeanModel = genListBenchNameMean(benchOutcomeModel)
     val zippedMeanStud = genListBenchNameMean(benchOutcomeStudent)
   }

--- a/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
+++ b/backend/complexity_analyser/src/main/scala/complexity_analyser/HaskellProcessor.scala
@@ -11,7 +11,7 @@ class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
   private final val BENCH_NAME = "/Bench.hs"
   private final val MATCH_BMARK = "benchmarking tests/[a-zA-Z0-9]+".r
   private final val MATCH_MEAN = "[0-9]+\\.[0-9]+".r
-  private final def benchFlags(o: File) = s"--regress cycles:time --output=$o/res.html"
+  private final def benchFlags(o: File) = s"--output=$o/res.html"
 
   /**
     * Copies Bench.hs to both model solution and student submission
@@ -52,9 +52,9 @@ class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
   private def produceDelta(zippedMeanModel: Seq[(String, Double)], zippedMeanStud: Seq[(String, Double)]) = {
     val buff = new ArrayBuffer[(String, Double)]
     for ((e, i) <- zippedMeanModel.zipWithIndex) {
-      val (name, modY) = e
-      val (_, studY) = zippedMeanStud.apply(i)
-      buff += ((name, modY - studY))
+      val (name, modMean) = e
+      val (_, studMean) = zippedMeanStud.apply(i)
+      buff += ((name, modMean - studMean))
     }
     buff
   }
@@ -62,7 +62,7 @@ class HaskellProcessor(modelAnswer: File, studentSubmission: File) {
   private def genListBenchNameMean(outcome: String) = {
     val names = MATCH_BMARK.findAllMatchIn(outcome).map(_.toString())
     val details = MATCH_BMARK.split(outcome)
-    val means = details.flatMap(_.split("\n")).filter(_.trim.startsWith("y"))
+    val means = details.flatMap(_.split("\n")).filter(_.trim.startsWith("mean"))
     val doubles = means.map(e => MATCH_MEAN.findFirstIn(e).get.toDouble)
     names.toSeq.zip(doubles)
   }

--- a/backend/complexity_analyser/testFiles/MP/student/MP.hs
+++ b/backend/complexity_analyser/testFiles/MP/student/MP.hs
@@ -1,0 +1,91 @@
+module MP where
+
+import System.Environment
+
+type FileContents = String
+
+type Keyword      = String
+type KeywordValue = String
+type KeywordDefs  = [(Keyword, KeywordValue)]
+
+separators :: String
+separators
+  = " \n\t.,:;!\"\'()<>/\\"
+
+
+lookUp :: String -> [(String, a)] -> [a]
+lookUp x [] = []
+lookUp x ((key , value) : xs)
+  | x == key = value : (lookUp x xs)
+  | otherwise = lookUp x xs
+
+
+split :: [Char] -> String -> (String, [String])
+split sep [] = ([], [""])
+split sep (x : xs)
+  | elem x sep = (x : seplist, "" : word : rest)
+  | otherwise = (seplist, (x : word) : rest)
+    where (seplist, word : rest) = split sep xs
+
+
+combine :: String -> [String] -> [String]
+combine sep [] = [sep]
+combine [] xs = xs
+combine (y : sep) (x : xs)
+  = x:[y]:rest
+    where rest = combine sep xs
+-- if x == "", it will be concatenated, but it will not
+
+getKeywordDefs :: [String] -> KeywordDefs
+getKeywordDefs [] = []
+getKeywordDefs (x : xs)
+  = (head r, concat(combine (drop 1 sep) (tail r))) : getKeywordDefs xs
+  where
+    (sep, r) = split " " x
+
+
+expand :: FileContents -> FileContents -> FileContents
+expand [] _ = []
+expand input keys
+  = concat (combine sep [replaceWord x (getKeywordDefs keys') | x <- words])
+  where
+    (sep, words) = split separators input
+    (sep2, keys') = split "\n" keys
+
+
+replaceWord :: String -> KeywordDefs -> String
+replaceWord xs [] = xs
+replaceWord xs ((key , val) : def)
+  | xs == key = val
+  | otherwise = replaceWord xs def
+
+-- expandext is the function implemented so that the algorithm
+-- expands the input file once for each set of definitions.
+
+-- I have used the map function so that I could concatenate the
+-- string of dashes "-----", the endline "\n" and the output from
+-- the list comprehension
+
+expandext :: FileContents -> FileContents -> FileContents
+expandext [] _ = []
+expandext input keys
+  = concat ( map (++"----- \n") [(expand input str1) | str1 <- v])
+  where
+    (sep3, v) = split "#" keys
+
+
+main :: IO ()
+-- The provided main program which uses your functions to merge a
+-- template and source file.
+main = do
+  args <- getArgs
+  main' args
+
+  where
+    main' :: [String] -> IO ()
+    main' [template, source, output] = do
+      t <- readFile template
+      i <- readFile source
+-- I have changed the output so that it calls function expandext instead
+      writeFile output (expandext t i)
+    main' _ = putStrLn ("Usage: runghc MP <template> <info> <output>")

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,5 +14,6 @@
     <module>postprocessor</module>
     <module>comment-cleaner</module>
     <module>compile-checker</module>
+    <module>complexity_analyser</module>
   </modules>
 </project>


### PR DESCRIPTION
This Microservice runs tests (the ones that can be run by `runghc Tests.hs`) and deducts marks if they do not pass completely, adding an error saying how many tests did not pass (does not add the details of why each test failed)

Then, the microservice also performs some complexity analysis based on the time of execution.
This Microservice is based on [Criterion](https://hackage.haskell.org/package/criterion) which can be installed through `cabal install criterion` or by following the instructions on their site

We benchmark each group of tests, and then we compare the mean time of execution between the student submission and the model solution


TODO:
* Add comments
* Check scores